### PR TITLE
New register class

### DIFF
--- a/src/exampleVaem.py
+++ b/src/exampleVaem.py
@@ -8,12 +8,11 @@ if __name__ == "__main__":
     vaemConfig = VaemConfig("192.168.8.118", 502, 0)
 
     try:
-        vaem = vaemDriver(vaemConfig, logger=logging)
+        vaem = vaemDriver(vaemConfig, logger=logging.Logger("vaem_logger"))
     except Exception as e:
         print(e)
 
     def func():
-        vaem._vaem_init()
         print(vaem.get_status())
         vaem.select_valve(3)
         print(vaem.get_status())

--- a/src/pyvaem/vaemHelper.py
+++ b/src/pyvaem/vaemHelper.py
@@ -166,7 +166,7 @@ class VaemOperatingMode(IntEnum):
     OpMode3 = 0x02
 
 
-def parse_statusword(statusWord):
+def parse_statusword(statusWord: int):
     status = {}
     status["Status"] = statusWord & 0x01
     status["Error"] = (statusWord & 0x08) >> 3
@@ -183,64 +183,48 @@ def parse_statusword(statusWord):
     return status
 
 
-def get_transfer_value(param, valve, opperation, **settings) -> VaemRegisters:
-    out = {}
-    if param == VaemIndex.NominalVoltage:
-        out["access"] = opperation
-        out["dataType"] = VaemDataType.UINT16.value
-        out["paramIndex"] = VaemIndex.NominalVoltage.value
-        out["paramSubIndex"] = valve
-        out["errorRet"] = 0
-        out["transferValue"] = settings["NominalVoltage"]
-    elif param == VaemIndex.ResponseTime:
-        out["access"] = opperation
-        out["dataType"] = VaemDataType.UINT32.value
-        out["paramIndex"] = VaemIndex.ResponseTime.value
-        out["paramSubIndex"] = valve
-        out["errorRet"] = 0
-        out["transferValue"] = settings["ResponseTime"]
-    elif param == VaemIndex.InrushCurrent:
-        out["access"] = opperation
-        out["dataType"] = VaemDataType.UINT16.value
-        out["paramIndex"] = VaemIndex.InrushCurrent.value
-        out["paramSubIndex"] = valve
-        out["errorRet"] = 0
-        out["transferValue"] = settings["InrushCurrent"]
-    elif param == VaemIndex.HoldingCurrent:
-        out["access"] = opperation
-        out["dataType"] = VaemDataType.UINT16.value
-        out["paramIndex"] = VaemIndex.HoldingCurrent.value
-        out["paramSubIndex"] = valve
-        out["errorRet"] = 0
-        out["transferValue"] = settings["HoldingCurrent"]
-    elif param == VaemIndex.PickUpTime:
-        out["access"] = opperation
-        out["dataType"] = VaemDataType.UINT16.value
-        out["paramIndex"] = VaemIndex.PickUpTime.value
-        out["paramSubIndex"] = valve
-        out["errorRet"] = 0
-        out["transferValue"] = settings["PickUpTime"]
-    elif param == VaemIndex.TimeDelay:
-        out["access"] = opperation
-        out["dataType"] = VaemDataType.UINT32.value
-        out["paramIndex"] = VaemIndex.TimeDelay.value
-        out["paramSubIndex"] = valve
-        out["errorRet"] = 0
-        out["transferValue"] = settings["TimeDelay"]
-    elif param == VaemIndex.HitNHold:
-        out["access"] = opperation
-        out["dataType"] = VaemDataType.UINT32.value
-        out["paramIndex"] = VaemIndex.HitNHold.value
-        out["paramSubIndex"] = valve
-        out["errorRet"] = 0
-        out["transferValue"] = settings["HitNHold"]
-    elif param == VaemIndex.SelectValve:
-        out["access"] = opperation
-        out["dataType"] = VaemDataType.UINT8.value
-        out["paramIndex"] = VaemIndex.SelectValve.value
-        out["paramSubIndex"] = 0
-        out["errorRet"] = 0
-        out["transferValue"] = valve
-    else:
-        print("Invalid input param")
-    return VaemRegisters.from_dict(out)
+SETTING_DATA_TYPES = {
+    VaemIndex.NominalVoltage: VaemDataType.UINT16,
+    VaemIndex.ResponseTime: VaemDataType.UINT32,
+    VaemIndex.InrushCurrent: VaemDataType.UINT16,
+    VaemIndex.HoldingCurrent: VaemDataType.UINT16,
+    VaemIndex.PickUpTime: VaemDataType.UINT16,
+    VaemIndex.TimeDelay: VaemDataType.UINT32,
+    VaemIndex.HitNHold: VaemDataType.UINT32,
+    VaemIndex.SelectValve: VaemDataType.UINT8,
+}
+
+
+def create_setting_registers(
+    param: VaemIndex, valve: int, operation: int, **settings
+) -> VaemRegisters:
+    return VaemRegisters(
+        access=operation,
+        dataType=SETTING_DATA_TYPES[param].value,
+        paramIndex=param.value,
+        paramSubIndex=valve,
+        errorRet=0,
+        transferValue=settings.get(param.name, 0),
+    )
+
+
+def create_select_valve_registers(operation: int, valve_code: int) -> VaemRegisters:
+    return VaemRegisters(
+        access=operation,
+        dataType=VaemDataType.UINT8.value,
+        paramIndex=VaemIndex.SelectValve.value,
+        paramSubIndex=0,
+        errorRet=0,
+        transferValue=valve_code,
+    )
+
+
+def create_controlword_registers(operation: int, control_word: int) -> VaemRegisters:
+    return VaemRegisters(
+        access=operation,
+        dataType=VaemDataType.UINT16.value,
+        paramIndex=VaemIndex.ControlWord.value,
+        paramSubIndex=0,
+        errorRet=0,
+        transferValue=control_word,
+    )


### PR DESCRIPTION
Implement a new registers dataclass for easier readability and maintainability.

Changes:
```
- implement new data transfer class VaemRegisters with conversion methods.
- streamline command transfer with read, write and conversion in a single function
- streamline register creation by replacing get_transfer_value with create_setting_registers  and create_select_valve_registers and implementing create_control_word_registers
- add set_operating_mode method
```
