### PR TITLE
Fix after test

### DIFF
--- a/src/pyvaem/VaemDriver.py
+++ b/src/pyvaem/VaemDriver.py
@@ -101,8 +101,8 @@ class vaemDriver:
                 read_address=readParam["address"],
                 read_count=readParam["length"],
                 write_address=writeParam["address"],
-                write_registers=writeData,
-                unit=self._config.slave_id,
+                values=writeData,
+                slave=self._config.slave_id,
             )
             return data.registers
         except Exception as e:

--- a/src/pyvaem/VaemDriver.py
+++ b/src/pyvaem/VaemDriver.py
@@ -92,7 +92,7 @@ class vaemDriver:
 
     def _initialize(self):
         # Set operating mode to API control
-        self.set_operating_mode(VaemOperatingMode.OpMode1.value)
+        self.set_operating_mode(VaemOperatingMode.OpMode1)
         self._clear_error()
 
     def _read_write_registers(self, writeData: list) -> list:

--- a/src/pyvaem/vaemHelper.py
+++ b/src/pyvaem/vaemHelper.py
@@ -12,7 +12,7 @@ class VaemIndex(IntEnum):
     ResponseTime = 0x07
     PickUpTime = 0x08
     OperatingMode = 0x09
-    SaveParameters = 0x11
+    SaveParameters = 0x0B
     SelectValve = 0x13
     TimeDelay = 0x16
     HitNHold = 0x2E
@@ -22,9 +22,9 @@ VaemRanges: dict[str, tuple] = {
     "NominalVoltage": (8000, 24000 + 1),
     "InrushCurrent": (20, 1000 + 1),
     "HoldingCurrent": (20, 400 + 1),
-    "ResponseTime": (1, (2**32), -1 + 1),
+    "ResponseTime": (1, (2**32) -1 + 1),
     "PickUpTime": (1, 500 + 1),
-    "TimeDelay": (0, (2**32), -1 + 1),
+    "TimeDelay": (0, (2**32) -1 + 1),
     "HitNHold": (0, 1000 + 1),
     "SelectValve": (0, 255 + 1),
 }
@@ -205,7 +205,7 @@ SETTING_DATA_TYPES = {
     VaemIndex.ResponseTime: VaemDataType.UINT32,
     VaemIndex.InrushCurrent: VaemDataType.UINT16,
     VaemIndex.HoldingCurrent: VaemDataType.UINT16,
-    VaemIndex.PickUpTime: VaemDataType.UINT16,
+    VaemIndex.PickUpTime: VaemDataType.UINT32, # Documentation says UINT16 but it requires UINT32
     VaemIndex.TimeDelay: VaemDataType.UINT32,
     VaemIndex.HitNHold: VaemDataType.UINT32,
     VaemIndex.SelectValve: VaemDataType.UINT8,


### PR DESCRIPTION
Fixes after test in real machine

Changes:
```
- correct tuple syntax in VaemRanges for ResponseTime and TimeDelay
- update set_operating_mode to use enum directly in _initialize method
- correct SaveParameters index value
- update PickUpTime data type to UINT32
- update parameter names in readwrite_registers to match those of version 3

```