### PR TITLE
New package structure

### DIFF
--- a/src/example_usage.py
+++ b/src/example_usage.py
@@ -1,23 +1,21 @@
-import logging
 import time
-from pyvaem.VaemDriver import VaemDriver
-from pyvaem.vaemHelper import ValveSettings
-from pyvaem.dataTypes import VaemConfig
+from logging import Logger
 
+from pyvaem import VaemConfig, VaemDriver, ValveSettings
 
 if __name__ == "__main__":
-    vaemConfig = VaemConfig("192.168.8.118", 502, 0)
+    vaem_config = VaemConfig("192.168.8.118", 502, 0)
 
     try:
-        vaem = VaemDriver(vaemConfig, logger=logging.Logger("vaem_logger"))
+        vaem = VaemDriver(vaem_config, logger=Logger("vaem_logger"))
     except Exception as e:
         print(e)
 
-    def func():
+    def example():
         # Example usage
         # Set per-valve settings using a dictionary
         for valve in range(1, 9):
-            vaem.set_multiple_valve_settings(
+            vaem.set_valve_settings(
                 valve,
                 {
                     "NominalVoltage": 24000,
@@ -29,10 +27,10 @@ if __name__ == "__main__":
                     "HoldingCurrent": 100,
                 },
             )
-        
+
         # Or using a ValveSettings object
         for valve in range(1, 9):
-            vaem.set_multiple_valve_settings(
+            vaem.set_valve_settings(
                 valve,
                 ValveSettings(
                     NominalVoltage=24000,
@@ -44,18 +42,33 @@ if __name__ == "__main__":
                     HoldingCurrent=100,
                 ),
             )
-        
-        # Call save_settings to apply the changes
+
+        # If not specified, setting will be set as default
+        # (same will happen if a dict is used)
+        for valve in range(1, 9):
+            vaem.set_valve_settings(
+                valve,
+                ValveSettings(
+                    NominalVoltage=24000,
+                    # ResponseTime will be 500,
+                    TimeDelay=0,
+                    PickUpTime=125,
+                    # InrushCurrent will be 300,
+                    HitNHold=100,
+                    HoldingCurrent=100,
+                ),
+            )
+
+        # Optional: Call save_settings to save settings to the memory of the VAEM
         vaem.save_settings()
 
         # Select multiple valves in one call
         vaem.select_valves([1, 1, 1, 0, 0, 0, 0, 0])  # Select valves 1, 2 and 3
 
         # Read the device status
-        # Get status returns the status of the device
-        # and which valves are selected in a dict format
+        # Get status returns the status of the device including selected valves
         print(vaem.get_status())
-        # Read valves state returns just the states (selected or not) as a list
+        # Read valves state returns just the selected states as a tuple
         print(vaem.read_valves_state())
 
         vaem.open_valves()  # Open selected valves
@@ -73,4 +86,4 @@ if __name__ == "__main__":
         time.sleep(3)
         vaem.close_valves()  # Close all valves
 
-    func()
+    example()

--- a/src/pyvaem/__init__.py
+++ b/src/pyvaem/__init__.py
@@ -1,2 +1,2 @@
-from .VaemDriver import VaemDriver
-from .dataTypes import VaemConfig
+from pyvaem.config import VaemConfig, ValveSettings
+from pyvaem.driver import VaemDriver

--- a/src/pyvaem/config.py
+++ b/src/pyvaem/config.py
@@ -1,0 +1,50 @@
+from dataclasses import dataclass
+
+from pyvaem.utils import VaemIndex
+
+
+@dataclass
+class VaemConfig:
+    ip: str
+    port: int
+    slave_id: int
+
+
+@dataclass(frozen=True)
+class ValveSettings:
+    NominalVoltage: int = 24000
+    ResponseTime: int = 500
+    TimeDelay: int = 0
+    PickUpTime: int = 125
+    InrushCurrent: int = 300
+    HitNHold: int = 100
+    HoldingCurrent: int = 100
+
+    # Mapping from field names to VaemIndex enums
+    _FIELD_TO_ENUM = {
+        "NominalVoltage": VaemIndex.NominalVoltage,
+        "ResponseTime": VaemIndex.ResponseTime,
+        "TimeDelay": VaemIndex.TimeDelay,
+        "PickUpTime": VaemIndex.PickUpTime,
+        "InrushCurrent": VaemIndex.InrushCurrent,
+        "HitNHold": VaemIndex.HitNHold,
+        "HoldingCurrent": VaemIndex.HoldingCurrent,
+    }
+
+    @classmethod
+    def from_dict(cls, data: dict | None = None) -> "ValveSettings":
+        """Create ValveSettings from dictionary with defaults for missing values."""
+        if not data:
+            return cls()
+        return cls(**data)
+
+    def to_dict(self) -> dict:
+        return self.__dict__
+
+    def to_enum_dict(self) -> dict[VaemIndex, int]:
+        """Convert to dict with VaemIndex keys."""
+        return {
+            self._FIELD_TO_ENUM[field_name]: value
+            for field_name, value in self.__dict__.items()
+            if field_name in self._FIELD_TO_ENUM
+        }

--- a/src/pyvaem/dataTypes.py
+++ b/src/pyvaem/dataTypes.py
@@ -1,8 +1,0 @@
-from dataclasses import dataclass
-
-
-@dataclass
-class VaemConfig:
-    ip: str
-    port: int
-    slave_id: int

--- a/src/pyvaem/driver.py
+++ b/src/pyvaem/driver.py
@@ -14,45 +14,13 @@ from pyvaem.utils import (
     create_controlword_registers,
     create_select_valve_registers,
     create_setting_registers,
+    error_msgs,
+    error_types,
     parse_statusword,
     vaem_parameters,
     vaem_ranges,
     valve_indexes,
 )
-
-error_msgs: dict[int, str] = {
-    0: "Ready for operation, no error",
-    34: "Invalid index",
-    35: "Invalid subindex",
-    36: "Read request cannot be processed",
-    37: "Write request cannot be processed",
-    41: "Specified value falls below the minimum value",
-    42: "The specified value exceeds the maximum value",
-    43: "Incorrect transfer value",
-    44: "Data type incorrect",
-    93: "General syntax error",
-    94: "Syntax error index (variable x)",
-    95: "Syntax error subindex (variable y)",
-    96: "Syntax error value",
-    97: "Command execution aborted",
-}
-
-error_types: dict[int, type[Exception]] = {
-    34: IndexError,
-    35: IndexError,
-    36: PermissionError,
-    37: PermissionError,
-    41: ValueError,
-    42: ValueError,
-    43: ValueError,
-    44: TypeError,
-    93: ValueError,
-    94: ValueError,
-    95: ValueError,
-    96: ValueError,
-    97: RuntimeError,
-}
-
 
 P = ParamSpec("P")
 R = TypeVar("R", bound=VaemRegisters)

--- a/src/pyvaem/utils.py
+++ b/src/pyvaem/utils.py
@@ -196,3 +196,37 @@ def create_controlword_registers(operation: int, control_word: int) -> VaemRegis
         errorRet=0,
         transferValue=control_word,
     )
+
+
+error_msgs: dict[int, str] = {
+    0: "Ready for operation, no error",
+    34: "Invalid index",
+    35: "Invalid subindex",
+    36: "Read request cannot be processed",
+    37: "Write request cannot be processed",
+    41: "Specified value falls below the minimum value",
+    42: "The specified value exceeds the maximum value",
+    43: "Incorrect transfer value",
+    44: "Data type incorrect",
+    93: "General syntax error",
+    94: "Syntax error index (variable x)",
+    95: "Syntax error subindex (variable y)",
+    96: "Syntax error value",
+    97: "Command execution aborted",
+}
+
+error_types: dict[int, type[Exception]] = {
+    34: IndexError,
+    35: IndexError,
+    36: PermissionError,
+    37: PermissionError,
+    41: ValueError,
+    42: ValueError,
+    43: ValueError,
+    44: TypeError,
+    93: ValueError,
+    94: ValueError,
+    95: ValueError,
+    96: ValueError,
+    97: RuntimeError,
+}

--- a/src/pyvaem/utils.py
+++ b/src/pyvaem/utils.py
@@ -42,46 +42,6 @@ vaem_ranges: dict[str, tuple] = {
 }
 
 
-@dataclass(frozen=True)
-class ValveSettings:
-    NominalVoltage: int = 24000
-    ResponseTime: int = 500
-    TimeDelay: int = 0
-    PickUpTime: int = 125
-    InrushCurrent: int = 300
-    HitNHold: int = 100
-    HoldingCurrent: int = 100
-
-    # Mapping from field names to VaemIndex enums
-    _FIELD_TO_ENUM = {
-        "NominalVoltage": VaemIndex.NominalVoltage,
-        "ResponseTime": VaemIndex.ResponseTime,
-        "TimeDelay": VaemIndex.TimeDelay,
-        "PickUpTime": VaemIndex.PickUpTime,
-        "InrushCurrent": VaemIndex.InrushCurrent,
-        "HitNHold": VaemIndex.HitNHold,
-        "HoldingCurrent": VaemIndex.HoldingCurrent,
-    }
-
-    @classmethod
-    def from_dict(cls, data: dict | None = None) -> "ValveSettings":
-        """Create ValveSettings from dictionary with defaults for missing values."""
-        if not data:
-            return cls()
-        return cls(**data)
-
-    def to_dict(self) -> dict:
-        return self.__dict__
-
-    def to_enum_dict(self) -> dict[VaemIndex, int]:
-        """Convert to dict with VaemIndex keys."""
-        return {
-            self._FIELD_TO_ENUM[field_name]: value
-            for field_name, value in self.__dict__.items()
-            if field_name in self._FIELD_TO_ENUM
-        }
-
-
 valve_indexes = {
     1: 0x01,
     2: 0x02,


### PR DESCRIPTION
Improved clarity of module names in package.

Changes:
  - rename `VaemDriver.py` to `driver.py`.
  - rename `dataTypes.py` to `config.py`
  - rename `vaemHelper.py` to `utils.py`
  - update imports in __init__.py to reflect updated structure.
  - update example usage to reflect module renames and include further examples.
  - move `error_msgs` and `error_types` to `utils.py`

Out of scope changes:
  - make `set_valve_setting` and `read_valve_setting` private methods and rename `set_all_valve_settings` and `read_all_valve_settings` to `set_valve_settings` and `read_valve_settings` respectively. Users should now only use these.