### PR TITLE
Add clarification on delay in `open_valves` method.

### DIFF
--- a/src/pyvaem/driver.py
+++ b/src/pyvaem/driver.py
@@ -275,7 +275,7 @@ class VaemDriver:
     def open_valves(self) -> VaemRegisters:
         """Start all valves that are selected"""
         self._reset_control_word()
-        time.sleep(0.1)
+        time.sleep(0.1) # A small delay is needed to ensure the control word is reset before writing the start valves command
         data = create_controlword_registers(
             VaemAccess.Write.value, VaemControlWords.StartValves.value
         )


### PR DESCRIPTION
### Purpose
Delay between resetting the control word and setting it to the start bit in `open_valves` appears to be very important for the correct operation of the valves. It is important to clarify why it is there to make sure it is preserved.

### Changes
Add comment to clarify purpose of delay in `open_valves` method.